### PR TITLE
Use CPU versions of pyTorch

### DIFF
--- a/cerulean_cloud/cloud_run_offset_tiles/requirements.txt
+++ b/cerulean_cloud/cloud_run_offset_tiles/requirements.txt
@@ -3,8 +3,9 @@ starlette-cramjam==0.1.0
 uvicorn[standard]
 rasterio==1.3.0
 setuptools==59.5.0
-torch==1.11.0
-torchvision==0.12.0
+-f https://download.pytorch.org/whl/cpu/torch_stable.html
+torch==1.11.0+cpu
+torchvision==0.12.0+cpu
 numpy<2.0.0
 typing-inspect
 fastapi-utils

--- a/cerulean_cloud/cloud_run_orchestrator/requirements.txt
+++ b/cerulean_cloud/cloud_run_orchestrator/requirements.txt
@@ -24,8 +24,9 @@ pygeos
 networkx
 google-cloud-tasks
 protobuf
-torch==1.11.0
-torchvision==0.12.0
+-f https://download.pytorch.org/whl/cpu/torch_stable.html
+torch==1.11.0+cpu
+torchvision==0.12.0+cpu
 scipy
 scikit-image
 pydantic<2.0


### PR DESCRIPTION
## What I'm changing

Reviewing deployments, I noted that a sizeable amount of time was spent pushing images to GCR.  For example, from the timestamped logs of [Test Deployment #1559](https://github.com/SkyTruth/cerulean-cloud/actions/runs/12472080696/job/34810286177), we can extract the beginning and end of each images uploads: 

```
2024-12-23T19:45:44.0779236Z  ~  docker:index:Image cerulean-cloud-images-test-cr-tipg-image updating (53s) [diff: ~build]; Pushing [>                                                  ]  551.4kB/330.1MB
2024-12-23T19:46:00.4775791Z  ~  docker:index:Image cerulean-cloud-images-test-cr-tipg-image updating (69s) [diff: ~build]; Pushing [==================================================>]  332.7MB

2024-12-23T19:46:55.9668891Z  ~  docker:index:Image cerulean-cloud-images-test-cr-offset-tile-image updating (125s) [diff: ~build]; Pushing [>                                                  ]  551.4kB/2.426GB
2024-12-23T19:48:46.7299195Z  ~  docker:index:Image cerulean-cloud-images-test-cr-offset-tile-image updating (236s) [diff: ~build]; Pushing [==================================================>]  2.445GB

2024-12-23T19:47:27.4741619Z  ~  docker:index:Image cerulean-cloud-images-test-cr-orchestrator-image updating (157s) [diff: ~build]; Pushing [>                                                  ]  551.4kB/2.569GB
2024-12-23T19:49:10.9937373Z  ~  docker:index:Image cerulean-cloud-images-test-cr-orchestrator-image updating (260s) [diff: ~build]; Pushing [==================================================>]  2.593GB

``` 

This results in roughly 2min of time spent uploading images.

I was surprised by the large size of docker images, given that the [distroless](https://github.com/GoogleContainerTools/distroless) base images being used advertises:

> Distroless images are _very small_. 

Given that our builds seem to do the right things (using separate stages for builds and applications), I reviewed the largest image and noted that the majority of its diskspace was consumed by a single file, `/app/site-packages/torch/lib/libtorch_cuda.so`:


```
▶ docker run \
  --rm -it \
  --entrypoint ls \
  gcr.io/cerulean-338116/cerulean-cloud-images-test-cloud-run-offset-tile-image:latest \
  -lah /app/site-packages/torch/lib
/app/site-packages/torch/lib:
total 1G
drwxr-xr-x    2 root     root        4.0K Aug 22 04:38 .
drwxr-xr-x   35 root     root        4.0K Aug 22 04:38 ..
-rwxr-xr-x    1 root     root      681.9K Aug 22 04:38 libc10.so
-rwxr-xr-x    1 root     root        1.0M Aug 22 04:38 libc10_cuda.so
-rwxr-xr-x    1 root     root       20.9K Aug 22 04:38 libcaffe2_nvrtc.so
-rwxr-xr-x    1 root     root      511.5K Aug 22 04:38 libcudart-80664282.so.10.2
-rwxr-xr-x    1 root     root      164.8K Aug 22 04:38 libgomp-a34b3233.so.1
-rwxr-xr-x    1 root     root       42.5K Aug 22 04:38 libnvToolsExt-3965bdd0.so.1
-rwxr-xr-x    1 root     root       21.0M Aug 22 04:38 libnvrtc-08c4863f.so.10.2
-rwxr-xr-x    1 root     root        4.6M Aug 22 04:38 libnvrtc-builtins.so
-rwxr-xr-x    1 root     root       35.6K Aug 22 04:38 libshm.so
-rwxr-xr-x    1 root     root      113.5K Aug 22 04:38 libtorch.so
-rwxr-xr-x    1 root     root      432.1M Aug 22 04:38 libtorch_cpu.so
-rwxr-xr-x    1 root     root      993.2M Aug 22 04:38 libtorch_cuda.so
-rwxr-xr-x    1 root     root       12.3K Aug 22 04:38 libtorch_global_deps.so
-rwxr-xr-x    1 root     root       16.5M Aug 22 04:38 libtorch_python.so
```


This PR installs the CPU version of pyTorch.  By doing so, we reduce two of the three images' disksizes by half:

| Image                                              | Before  | After   | Notes      |
| -------------------------------------------------- | ------- | ------- | ---------- |
| `cerulean-cloud-images-test-cr-tipg-image`         | 0.22 GB | 0.22 GB |            |
| `cerulean-cloud-images-test-cr-orchestrator-image` | 0.99 GB | 0.44 GB | Uses torch |
| `cerulean-cloud-images-test-cr-offset-tile-image`  | 1.00 GB | 0.49 GB | Uses torch |

## How I did it

By instructing `pip` to fetch wheels from `https://download.pytorch.org/whl/cpu/torch_stable.html` and appending `+cpu` to the version, a CPU-only version is installed.

## Concerns

> [!CAUTION]
> I could find no sign of the project using GPUs, but this should be verified by more informed team members prior to merging.