### PR TITLE
removed duplicate dryrun_alerts definition

### DIFF
--- a/stack/stack_config/Pulumi.staging.yaml
+++ b/stack/stack_config/Pulumi.staging.yaml
@@ -9,7 +9,6 @@ config:
   cerulean-cloud:keyname: staging-cerulean-cloud-api-key
   cerulean-cloud:infra_keyname: staging-gfw-infra-api-key
   cerulean-cloud:titiler_keyname: staging-titiler-api-key
-  cerulean-cloud:dryrun_alerts: "" # Make empty "" to turn on alerts
   db:db-instance: db-custom-4-15360
   db:db-mem: 599040
   db:db-password:


### PR DESCRIPTION
Ugh. Stupid duplicate definition 🙄 