### PR TITLE
Hotfix/update tipg timeouts

### DIFF
--- a/cerulean_cloud/cloud_run_tipg/handler.py
+++ b/cerulean_cloud/cloud_run_tipg/handler.py
@@ -214,6 +214,8 @@ async def startup_event() -> None:
             functions=db_settings.functions,
             exclude_functions=db_settings.exclude_functions,
             spatial=False,  # False means allow non-spatial tables
+            datetime_extent=False,  # Avoid precalculating datetime extent to speed up registration
+            spatial_extent=False,  # Avoid precalculating spatial extent to speed up registration
         )
     except asyncpg.exceptions.UndefinedObjectError:
         # This is the case where TiPG is attempting to start up BEFORE
@@ -247,6 +249,8 @@ async def register_table(request: Request):
         functions=db_settings.functions,
         exclude_functions=db_settings.exclude_functions,
         spatial=False,  # False means allow non-spatial tables
+        datetime_extent=False,  # Avoid precalculating datetime extent to speed up registration
+        spatial_extent=False,  # Avoid precalculating spatial extent to speed up registration
     )
 
 

--- a/stack/cloud_run_tipg.py
+++ b/stack/cloud_run_tipg.py
@@ -146,6 +146,9 @@ default = gcp.cloudrun.Service(
                         timeout_seconds=240,
                         period_seconds=240,
                         failure_threshold=3,
+                        tcp_socket=gcp.cloudrun.ServiceTemplateSpecContainerStartupProbeTcpSocketArgs(
+                            port=8080,
+                        ),
                     ),
                 ),
             ],

--- a/stack/cloud_run_tipg.py
+++ b/stack/cloud_run_tipg.py
@@ -126,7 +126,7 @@ default = gcp.cloudrun.Service(
                         ),
                         gcp.cloudrun.ServiceTemplateSpecContainerEnvArgs(
                             name="RESTRICTED_COLLECTIONS",
-                            value='["public.aoi_user","public.filter", "public.frequency", "public.verification_token", "public.accounts", "public.sessions", "public.subscription", "public.users", "public.slick_to_source", "public.source", "public.source_infra", "public.source_type", "public.source_vessel", "public.source_dark", "public.source_natural", "public.source_to_tag", "public.tag", "public.hitl_slick", "public.permission"]',
+                            value='["public.aoi_user","public.filter", "public.frequency", "public.verification_token", "public.accounts", "public.sessions", "public.subscription", "public.users", "public.slick_to_source", "public.source", "public.source_infra", "public.source_type", "public.source_vessel", "public.source_dark", "public.source_natural", "public.source_to_tag", "public.tag", "public.hitl_slick", "public.permission", "public.slick", "public.sentinel1_grd", "public.aoi_mpa", "public.aoi_iho", "public.aoi_eez", "public.slick_to_aoi", "public.aoi_chunks", "public.trigger", "public.orchestrator_run"]',
                             # EditTheDatabase
                         ),
                         gcp.cloudrun.ServiceTemplateSpecContainerEnvArgs(
@@ -142,6 +142,11 @@ default = gcp.cloudrun.Service(
                         ),
                     ],
                     resources=dict(limits=dict(memory="8Gi", cpu="6000m")),
+                    startup_probe=gcp.cloudrun.ServiceTemplateSpecContainerStartupProbeArgs(
+                        timeout_seconds=240,
+                        period_seconds=240,
+                        failure_threshold=3,
+                    ),
                 ),
             ],
             timeout_seconds=420,


### PR DESCRIPTION
Working to improve TiPG startup time. On one side, reducing the startup time by turning off the datetime and geospatial precalculations. On the other, allowing 3 times 4 minutes to start up.