### PR TITLE
Switch repeat_source to materialized view

### DIFF
--- a/stack/cloud_run_tipg.py
+++ b/stack/cloud_run_tipg.py
@@ -142,7 +142,7 @@ default = gcp.cloudrun.Service(
                         ),
                         gcp.cloudrun.ServiceTemplateSpecContainerEnvArgs(
                             name="RESTRICTED_COLLECTIONS",
-                            value='["public.aoi_user","public.filter", "public.frequency", "public.verification_token", "public.accounts", "public.sessions", "public.subscription", "public.users", "public.slick_to_source", "public.source", "public.source_infra", "public.source_type", "public.source_vessel", "public.source_dark", "public.source_natural", "public.source_to_tag", "public.tag", "public.hitl_slick", "public.permission", "public.slick", "public.slick_to_aoi", "public.aoi_chunks", "public.trigger", "public.orchestrator_run", "public.repeat_source", "public.repeat_source_cache"]',
+                            value='["public.aoi_user","public.filter", "public.frequency", "public.verification_token", "public.accounts", "public.sessions", "public.subscription", "public.users", "public.slick_to_source", "public.source", "public.source_infra", "public.source_type", "public.source_vessel", "public.source_dark", "public.source_natural", "public.source_to_tag", "public.tag", "public.hitl_slick", "public.permission", "public.slick", "public.slick_to_aoi", "public.aoi_chunks", "public.trigger", "public.orchestrator_run", "public.repeat_source"]',
                             # EditTheDatabase
                         ),
                         gcp.cloudrun.ServiceTemplateSpecContainerEnvArgs(


### PR DESCRIPTION
## Summary
- materialize the `repeat_source` view to precompute heavy query
- refresh the materialized view after updating `source_plus`
- adjust TIPG restricted collections

## Testing
- `ruff check alembic/versions/4a87d52cb4ea_add_cache_tables.py cerulean_cloud/database_client.py stack/cloud_run_tipg.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_683de79449c0832da3af9c807cec147a