### PR TITLE
Ensure slick_plus and source_plus tables populated

### DIFF
--- a/alembic/versions/9e8f7d6c5b4a_views_to_tables.py
+++ b/alembic/versions/9e8f7d6c5b4a_views_to_tables.py
@@ -300,6 +300,9 @@ def upgrade() -> None:
     op.execute("SELECT _rebuild_source_plus_rows(NULL)")
     op.execute("REFRESH MATERIALIZED VIEW repeat_source")
 
+    # ───────── 9. Ensure caches are current ─────────
+    op.execute("CALL refresh_all_slick_views()")
+
 
 def downgrade() -> None:
     op.execute("""


### PR DESCRIPTION
## Summary
- refresh the slick_plus and source_plus caches at the end of `9e8f7d6c5b4a_views_to_tables`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'dateutil')*


------
https://chatgpt.com/codex/tasks/task_e_683e05fce6d0832d991954d7aff8d5c8