### PR TITLE
Populate slick_plus cache in latest migration

### DIFF
--- a/alembic/versions/4a87d52cb4ea_add_cache_tables.py
+++ b/alembic/versions/4a87d52cb4ea_add_cache_tables.py
@@ -242,3 +242,75 @@ def downgrade() -> None:
         """,
     )
     op.create_entity(repeat_source)
+
+    # Populate the new cache tables with existing data
+    op.execute(
+        """
+        INSERT INTO slick_plus
+        SELECT
+            slick.*,
+            slick.length^2 / slick.area / slick.polsby_popper as linearity,
+            sentinel1_grd.scene_id AS s1_scene_id,
+            sentinel1_grd.geometry AS s1_geometry,
+            cls.short_name AS cls_short_name,
+            cls.long_name AS cls_long_name,
+            aoi_agg.aoi_type_1_ids,
+            aoi_agg.aoi_type_2_ids,
+            aoi_agg.aoi_type_3_ids,
+            source_agg.source_type_1_ids,
+            source_agg.source_type_2_ids,
+            source_agg.source_type_3_ids,
+            'https://cerulean.skytruth.org/slicks/' || slick.id::text ||'?ref=api&slick_id=' || slick.id AS slick_url
+        FROM slick
+        JOIN orchestrator_run ON orchestrator_run.id = slick.orchestrator_run
+        JOIN sentinel1_grd ON sentinel1_grd.id = orchestrator_run.sentinel1_grd
+        JOIN cls ON cls.id = slick.cls
+        LEFT JOIN (
+            SELECT slick_to_aoi.slick,
+                array_agg(aoi.id) FILTER (WHERE aoi.type = 1) AS aoi_type_1_ids,
+                array_agg(aoi.id) FILTER (WHERE aoi.type = 2) AS aoi_type_2_ids,
+                array_agg(aoi.id) FILTER (WHERE aoi.type = 3) AS aoi_type_3_ids
+            FROM slick_to_aoi
+            JOIN aoi ON slick_to_aoi.aoi = aoi.id
+            GROUP BY slick_to_aoi.slick
+        ) aoi_agg ON aoi_agg.slick = slick.id
+        LEFT JOIN (
+            SELECT slick_to_source.slick,
+                array_agg(source.id) FILTER (WHERE source.type = 1) AS source_type_1_ids,
+                array_agg(source.id) FILTER (WHERE source.type = 2) AS source_type_2_ids,
+                array_agg(source.id) FILTER (WHERE source.type = 3) AS source_type_3_ids
+            FROM slick_to_source
+            JOIN source ON slick_to_source.source = source.id
+            WHERE slick_to_source.active = true
+            GROUP BY slick_to_source.slick
+        ) source_agg ON source_agg.slick = slick.id
+        WHERE slick.active = true
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO source_plus
+        SELECT
+            sk.geometry as geometry,
+            sts.slick as slick_id,
+            sk.machine_confidence as slick_confidence,
+            s.id as source_id,
+            s.ext_id as mmsi_or_structure_id,
+            st.short_name as source_type,
+            sts.collated_score as source_collated_score,
+            sts.rank as source_rank,
+            sts.create_time as create_time,
+            sts.git_hash as git_tag,
+            'https://cerulean.skytruth.org/slicks/' || sk.id::text ||'?ref=api&slick_id=' || sk.id AS slick_url,
+            'https://cerulean.skytruth.org/?ref=api&' || st.ext_id_name || '=' || s.ext_id AS source_url
+        FROM slick_to_source sts
+        INNER JOIN source s ON sts.source = s.id
+        INNER JOIN slick sk ON sts.slick = sk.id AND sk.active = TRUE
+        INNER JOIN source_type st ON st.id = s.type
+        WHERE sts.active = TRUE
+        ORDER BY sts.slick DESC, sts.rank
+        """
+    )
+
+    op.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY repeat_source")


### PR DESCRIPTION
## Summary
- backfill slick_plus and source_plus in the `4a87d52cb4ea_add_cache_tables` migration

## Testing
- `ruff check alembic/versions/4a87d52cb4ea_add_cache_tables.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_683e07834e3c832dada0504b1aa6ae6a