### PR TITLE
Feat/old method

### DIFF
--- a/alembic/versions/3c4693517ef6_add_tables.py
+++ b/alembic/versions/3c4693517ef6_add_tables.py
@@ -159,15 +159,10 @@ def upgrade() -> None:
 
     op.create_table(
         "users",
-        sa.Column("id", sa.BigInteger, primary_key=True),
+        sa.Column("id", sa.Text, primary_key=True),
         sa.Column("firstName", sa.Text),
         sa.Column("lastName", sa.Text),
-        sa.Column(
-            "name",
-            sa.Text,
-            sa.Computed('"firstName" || \' \' || "lastName"', persisted=True),
-            nullable=False,
-        ),
+        sa.Column("name", sa.Text),
         sa.Column("email", sa.Text, nullable=False, unique=True),
         sa.Column("emailVerified", sa.Boolean, default=False),
         sa.Column("image", sa.Text),
@@ -212,7 +207,7 @@ def upgrade() -> None:
 
     op.create_table(
         "verifications",
-        sa.Column("id", sa.BigInteger, primary_key=True),
+        sa.Column("id", sa.Text, primary_key=True),
         sa.Column("identifier", sa.Text, nullable=False),
         sa.Column("value", sa.Text, nullable=False),
         sa.Column("expiresAt", sa.DateTime),
@@ -222,7 +217,7 @@ def upgrade() -> None:
 
     op.create_table(
         "accounts",
-        sa.Column("id", sa.BigInteger, primary_key=True),
+        sa.Column("id", sa.Text, primary_key=True),
         sa.Column("userId", sa.BigInteger, sa.ForeignKey("users.id"), nullable=False),
         sa.Column("providerId", sa.Text, nullable=False),
         sa.Column("accountId", sa.Text, nullable=False),
@@ -237,7 +232,7 @@ def upgrade() -> None:
 
     op.create_table(
         "sessions",
-        sa.Column("id", sa.BigInteger, primary_key=True),
+        sa.Column("id", sa.Text, primary_key=True),
         sa.Column("userId", sa.BigInteger, sa.ForeignKey("users.id"), nullable=False),
         sa.Column("expiresAt", sa.DateTime, nullable=False),
         sa.Column("token", sa.Text, nullable=False),

--- a/alembic/versions/3c4693517ef6_add_tables.py
+++ b/alembic/versions/3c4693517ef6_add_tables.py
@@ -179,6 +179,8 @@ def upgrade() -> None:
         sa.Column("banned", sa.Boolean, default=False),
         sa.Column("banReason", sa.Text),
         sa.Column("banExpires", sa.DateTime),
+        sa.Column("createdAt", sa.DateTime, server_default=sa.func.now()),
+        sa.Column("updatedAt", sa.DateTime, server_default=sa.func.now()),
     )
 
     op.create_table(
@@ -209,11 +211,13 @@ def upgrade() -> None:
     )
 
     op.create_table(
-        "verification_token",
+        "verifications",
+        sa.Column("id", sa.BigInteger, primary_key=True),
         sa.Column("identifier", sa.Text, nullable=False),
-        sa.Column("expires", sa.DateTime, nullable=False),
-        sa.Column("token", sa.Text, nullable=False),
-        sa.PrimaryKeyConstraint("identifier", "token"),
+        sa.Column("value", sa.Text, nullable=False),
+        sa.Column("expiresAt", sa.DateTime),
+        sa.Column("createdAt", sa.DateTime, server_default=sa.func.now()),
+        sa.Column("updatedAt", sa.DateTime, server_default=sa.func.now()),
     )
 
     op.create_table(
@@ -475,7 +479,7 @@ def downgrade() -> None:
     op.drop_table("aoi_eez")
     op.drop_table("aoi")
     op.drop_table("aoi_type")
-    op.drop_table("verification_token")
+    op.drop_table("verifications")
     op.drop_table("sessions")
     op.drop_table("accounts")
     op.drop_table("subscription")

--- a/alembic/versions/3c4693517ef6_add_tables.py
+++ b/alembic/versions/3c4693517ef6_add_tables.py
@@ -159,7 +159,7 @@ def upgrade() -> None:
 
     op.create_table(
         "users",
-        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("id", sa.BigInteger, primary_key=True),
         sa.Column("firstName", sa.Text),
         sa.Column("lastName", sa.Text),
         sa.Column("name", sa.Text),
@@ -207,7 +207,7 @@ def upgrade() -> None:
 
     op.create_table(
         "verifications",
-        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("id", sa.BigInteger, primary_key=True),
         sa.Column("identifier", sa.Text, nullable=False),
         sa.Column("value", sa.Text, nullable=False),
         sa.Column("expiresAt", sa.DateTime),
@@ -217,7 +217,7 @@ def upgrade() -> None:
 
     op.create_table(
         "accounts",
-        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("id", sa.BigInteger, primary_key=True),
         sa.Column("userId", sa.BigInteger, sa.ForeignKey("users.id"), nullable=False),
         sa.Column("providerId", sa.Text, nullable=False),
         sa.Column("accountId", sa.Text, nullable=False),
@@ -232,13 +232,15 @@ def upgrade() -> None:
 
     op.create_table(
         "sessions",
-        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("id", sa.BigInteger, primary_key=True),
         sa.Column("userId", sa.BigInteger, sa.ForeignKey("users.id"), nullable=False),
         sa.Column("expiresAt", sa.DateTime, nullable=False),
         sa.Column("token", sa.Text, nullable=False),
         sa.Column("createdAt", sa.DateTime, server_default=sa.func.now()),
         sa.Column("updatedAt", sa.DateTime, server_default=sa.func.now()),
         sa.Column("impersonatedBy", sa.Text),
+        sa.Column("ipAddress", sa.Text),
+        sa.Column("userAgent", sa.Text),
     )
 
     op.create_table(

--- a/alembic/versions/3c4693517ef6_add_tables.py
+++ b/alembic/versions/3c4693517ef6_add_tables.py
@@ -160,11 +160,25 @@ def upgrade() -> None:
     op.create_table(
         "users",
         sa.Column("id", sa.BigInteger, primary_key=True),
-        sa.Column("name", sa.Text),
-        sa.Column("email", sa.Text),
-        sa.Column("emailVerified", sa.DateTime),
+        sa.Column("firstName", sa.Text),
+        sa.Column("lastName", sa.Text),
+        sa.Column(
+            "name",
+            sa.Text,
+            sa.Computed('"firstName" || \' \' || "lastName"', persisted=True),
+            nullable=False,
+        ),
+        sa.Column("email", sa.Text, nullable=False, unique=True),
+        sa.Column("emailVerified", sa.Boolean, default=False),
         sa.Column("image", sa.Text),
         sa.Column("role", sa.Text),
+        sa.Column("organization", sa.Text),
+        sa.Column("organizationType", ARRAY(sa.Text)),
+        sa.Column("location", sa.Text),
+        sa.Column("emailConsent", sa.Boolean, default=False),
+        sa.Column("banned", sa.Boolean, default=False),
+        sa.Column("banReason", sa.Text),
+        sa.Column("banExpires", sa.DateTime),
     )
 
     op.create_table(
@@ -206,24 +220,26 @@ def upgrade() -> None:
         "accounts",
         sa.Column("id", sa.BigInteger, primary_key=True),
         sa.Column("userId", sa.BigInteger, sa.ForeignKey("users.id"), nullable=False),
-        sa.Column("type", sa.Text, nullable=False),
-        sa.Column("provider", sa.Text, nullable=False),
-        sa.Column("providerAccountId", sa.Text, nullable=False),
-        sa.Column("refresh_token", sa.Text),
-        sa.Column("access_token", sa.Text),
-        sa.Column("expires_at", sa.BigInteger),
-        sa.Column("id_token", sa.Text),
+        sa.Column("providerId", sa.Text, nullable=False),
+        sa.Column("accountId", sa.Text, nullable=False),
+        sa.Column("refreshToken", sa.Text),
+        sa.Column("accessToken", sa.Text),
+        sa.Column("accessTokenExpiresAt", sa.DateTime),
+        sa.Column("idToken", sa.Text),
         sa.Column("scope", sa.Text),
-        sa.Column("session_state", sa.Text),
-        sa.Column("token_type", sa.Text),
+        sa.Column("createdAt", sa.DateTime, server_default=sa.func.now()),
+        sa.Column("updatedAt", sa.DateTime, server_default=sa.func.now()),
     )
 
     op.create_table(
         "sessions",
         sa.Column("id", sa.BigInteger, primary_key=True),
         sa.Column("userId", sa.BigInteger, sa.ForeignKey("users.id"), nullable=False),
-        sa.Column("expires", sa.DateTime, nullable=False),
-        sa.Column("sessionToken", sa.Text, nullable=False),
+        sa.Column("expiresAt", sa.DateTime, nullable=False),
+        sa.Column("token", sa.Text, nullable=False),
+        sa.Column("createdAt", sa.DateTime, server_default=sa.func.now()),
+        sa.Column("updatedAt", sa.DateTime, server_default=sa.func.now()),
+        sa.Column("impersonatedBy", sa.Text),
     )
 
     op.create_table(

--- a/alembic/versions/c941681a050d_add_initial_records.py
+++ b/alembic/versions/c941681a050d_add_initial_records.py
@@ -257,13 +257,13 @@ def upgrade() -> None:
         session.add_all(permissions)
 
         first_user = database_schema.Users(
-            firstName="Jona",
-            lastName="Raphael",
-            email="jona@skytruth.org",
-            role="ADMIN",
-            organization="Cerulean",
-            organizationType=["company"],
-            location="Boston, MA",
+            firstName="dummy",
+            lastName="dummy",
+            email="dummy@dummy.dummy",
+            role="dummy",
+            organization="dummy",
+            organizationType=["dummy"],
+            location="dummy",
         )
         session.add(first_user)
         session.flush()  # guarantees system_user.id is available

--- a/alembic/versions/c941681a050d_add_initial_records.py
+++ b/alembic/versions/c941681a050d_add_initial_records.py
@@ -257,7 +257,13 @@ def upgrade() -> None:
         session.add_all(permissions)
 
         first_user = database_schema.Users(
-            name="jona", email="jona@cerulean.org", role="ADMIN"
+            firstName="Jona",
+            lastName="Raphael",
+            email="jona@skytruth.org",
+            role="ADMIN",
+            organization="Cerulean",
+            organizationType=["company"],
+            location="Boston, MA",
         )
         session.add(first_user)
         session.flush()  # guarantees system_user.id is available

--- a/cerulean_cloud/database_schema.py
+++ b/cerulean_cloud/database_schema.py
@@ -228,11 +228,7 @@ class Trigger(Base):  # noqa
 class Users(Base):  # noqa
     __tablename__ = "users"
 
-    id = Column(
-        BigInteger,
-        primary_key=True,
-        server_default=text("nextval('users_id_seq'::regclass)"),
-    )
+    id = Column(Text, primary_key=True)
     firstName = Column(Text)
     lastName = Column(Text)
     name = Column(
@@ -258,11 +254,7 @@ class Users(Base):  # noqa
 class Verifications(Base):  # noqa
     __tablename__ = "verifications"
 
-    id = Column(
-        BigInteger,
-        primary_key=True,
-        server_default=text("nextval('verifications_id_seq'::regclass)"),
-    )
+    id = Column(Text, primary_key=True)
     identifier = Column(Text, nullable=False)
     value = Column(Text, nullable=False)
     expiresAt = Column(DateTime)
@@ -273,11 +265,7 @@ class Verifications(Base):  # noqa
 class Accounts(Base):  # noqa
     __tablename__ = "accounts"
 
-    id = Column(
-        BigInteger,
-        primary_key=True,
-        server_default=text("nextval('accounts_id_seq'::regclass)"),
-    )
+    id = Column(Text, primary_key=True)
     userId = Column(ForeignKey("users.id"), nullable=False)
     providerId = Column(Text, nullable=False)
     accountId = Column(Text, nullable=False)
@@ -382,11 +370,7 @@ class OrchestratorRun(Base):  # noqa
 class Sessions(Base):  # noqa
     __tablename__ = "sessions"
 
-    id = Column(
-        BigInteger,
-        primary_key=True,
-        server_default=text("nextval('sessions_id_seq'::regclass)"),
-    )
+    id = Column(Text, primary_key=True)
     userId = Column(ForeignKey("users.id"), nullable=False)
     expiresAt = Column(DateTime, nullable=False)
     token = Column(Text, nullable=False)

--- a/cerulean_cloud/database_schema.py
+++ b/cerulean_cloud/database_schema.py
@@ -233,11 +233,24 @@ class Users(Base):  # noqa
         primary_key=True,
         server_default=text("nextval('users_id_seq'::regclass)"),
     )
-    name = Column(Text)
-    email = Column(Text)
-    emailVerified = Column(DateTime)
+    firstName = Column(Text)
+    lastName = Column(Text)
+    name = Column(
+        Text,
+        Computed('(("firstName" || \' \'::text) || "lastName")', persisted=True),
+        nullable=False,
+    )
+    email = Column(Text, nullable=False, unique=True)
+    emailVerified = Column(Boolean)
     image = Column(Text)
     role = Column(Text)
+    organization = Column(Text)
+    organizationType = Column(ARRAY(Text()))
+    location = Column(Text)
+    emailConsent = Column(Boolean)
+    banned = Column(Boolean)
+    banReason = Column(Text)
+    banExpires = Column(DateTime)
 
 
 class VerificationToken(Base):  # noqa
@@ -257,16 +270,15 @@ class Accounts(Base):  # noqa
         server_default=text("nextval('accounts_id_seq'::regclass)"),
     )
     userId = Column(ForeignKey("users.id"), nullable=False)
-    type = Column(Text, nullable=False)
-    provider = Column(Text, nullable=False)
-    providerAccountId = Column(Text, nullable=False)
-    refresh_token = Column(Text)
-    access_token = Column(Text)
-    expires_at = Column(BigInteger)
-    id_token = Column(Text)
+    providerId = Column(Text, nullable=False)
+    accountId = Column(Text, nullable=False)
+    refreshToken = Column(Text)
+    accessToken = Column(Text)
+    accessTokenExpiresAt = Column(DateTime)
+    idToken = Column(Text)
     scope = Column(Text)
-    session_state = Column(Text)
-    token_type = Column(Text)
+    createdAt = Column(DateTime, server_default=text("now()"))
+    updatedAt = Column(DateTime, server_default=text("now()"))
 
     users = relationship("Users")
 
@@ -367,8 +379,11 @@ class Sessions(Base):  # noqa
         server_default=text("nextval('sessions_id_seq'::regclass)"),
     )
     userId = Column(ForeignKey("users.id"), nullable=False)
-    expires = Column(DateTime, nullable=False)
-    sessionToken = Column(Text, nullable=False)
+    expiresAt = Column(DateTime, nullable=False)
+    token = Column(Text, nullable=False)
+    createdAt = Column(DateTime, server_default=text("now()"))
+    updatedAt = Column(DateTime, server_default=text("now()"))
+    impersonatedBy = Column(Text)
 
     users = relationship("Users")
 

--- a/cerulean_cloud/database_schema.py
+++ b/cerulean_cloud/database_schema.py
@@ -251,14 +251,23 @@ class Users(Base):  # noqa
     banned = Column(Boolean)
     banReason = Column(Text)
     banExpires = Column(DateTime)
+    createdAt = Column(DateTime, server_default=text("now()"))
+    updatedAt = Column(DateTime, server_default=text("now()"))
 
 
-class VerificationToken(Base):  # noqa
-    __tablename__ = "verification_token"
+class Verifications(Base):  # noqa
+    __tablename__ = "verifications"
 
-    identifier = Column(Text, primary_key=True, nullable=False)
-    expires = Column(DateTime, nullable=False)
-    token = Column(Text, primary_key=True, nullable=False)
+    id = Column(
+        BigInteger,
+        primary_key=True,
+        server_default=text("nextval('verifications_id_seq'::regclass)"),
+    )
+    identifier = Column(Text, nullable=False)
+    value = Column(Text, nullable=False)
+    expiresAt = Column(DateTime)
+    createdAt = Column(DateTime, server_default=text("now()"))
+    updatedAt = Column(DateTime, server_default=text("now()"))
 
 
 class Accounts(Base):  # noqa

--- a/cerulean_cloud/database_schema.py
+++ b/cerulean_cloud/database_schema.py
@@ -228,7 +228,7 @@ class Trigger(Base):  # noqa
 class Users(Base):  # noqa
     __tablename__ = "users"
 
-    id = Column(Text, primary_key=True)
+    id = Column(BigInteger, primary_key=True)
     firstName = Column(Text)
     lastName = Column(Text)
     name = Column(
@@ -254,7 +254,7 @@ class Users(Base):  # noqa
 class Verifications(Base):  # noqa
     __tablename__ = "verifications"
 
-    id = Column(Text, primary_key=True)
+    id = Column(BigInteger, primary_key=True)
     identifier = Column(Text, nullable=False)
     value = Column(Text, nullable=False)
     expiresAt = Column(DateTime)
@@ -265,7 +265,7 @@ class Verifications(Base):  # noqa
 class Accounts(Base):  # noqa
     __tablename__ = "accounts"
 
-    id = Column(Text, primary_key=True)
+    id = Column(BigInteger, primary_key=True)
     userId = Column(ForeignKey("users.id"), nullable=False)
     providerId = Column(Text, nullable=False)
     accountId = Column(Text, nullable=False)
@@ -370,13 +370,15 @@ class OrchestratorRun(Base):  # noqa
 class Sessions(Base):  # noqa
     __tablename__ = "sessions"
 
-    id = Column(Text, primary_key=True)
+    id = Column(BigInteger, primary_key=True)
     userId = Column(ForeignKey("users.id"), nullable=False)
     expiresAt = Column(DateTime, nullable=False)
     token = Column(Text, nullable=False)
     createdAt = Column(DateTime, server_default=text("now()"))
     updatedAt = Column(DateTime, server_default=text("now()"))
     impersonatedBy = Column(Text)
+    ipAddress = Column(Text)
+    userAgent = Column(Text)
 
     users = relationship("Users")
 


### PR DESCRIPTION
/* 1. Rename the current `name` column → `firstName` */
ALTER TABLE public.users
    RENAME COLUMN name TO "firstName";

/* 2. Change existing columns and add most new columns in one shot */
ALTER TABLE public.users
    /* ---- modify existing columns ---- */
    ALTER COLUMN "emailVerified" TYPE boolean
        USING ("emailVerified" IS NOT NULL),
    ALTER COLUMN "emailVerified" SET DEFAULT FALSE,

    ALTER COLUMN email SET NOT NULL,
    ADD UNIQUE (email),

    /* ---- add new simple columns ---- */
    ADD COLUMN "lastName"              text,
    ADD COLUMN "organization"          text,
    ADD COLUMN "organizationType"      text[],          -- ARRAY(sa.Text)
    ADD COLUMN "location"              text,
    ADD COLUMN "emailConsent"          boolean DEFAULT FALSE,
    ADD COLUMN "banned"                boolean DEFAULT FALSE,
    ADD COLUMN "banReason"             text,
    ADD COLUMN "banExpires"            timestamptz,
    ADD COLUMN "createdAt"             timestamptz DEFAULT now(),
    ADD COLUMN "updatedAt"             timestamptz DEFAULT now();

/* 3. Add the stored / persisted computed column that concatenates first & last names */
ALTER TABLE public.users
    ADD COLUMN "name" text
        GENERATED ALWAYS AS ("firstName" || ' ' || COALESCE("lastName", '')) STORED;

/* ----------  end migration  ---------- */


/* 0. Drop the old composite primary-key constraint (name may vary — adjust if needed) */
ALTER TABLE public.verification_token
    DROP CONSTRAINT IF EXISTS verification_token_pkey;

/* 1. Rename the table */
ALTER TABLE public.verification_token
    RENAME TO verifications;
ALTER TABLE public.verifications
	RENAME COLUMN token TO value;

/* 2. Rename `expires` → `expiresAt` and allow NULLs */
ALTER TABLE public.verifications
    RENAME COLUMN expires TO "expiresAt";
ALTER TABLE public.verifications
    ALTER COLUMN "expiresAt" DROP NOT NULL;

/* 4. Add new columns (do it all in one ALTER to minimize rewrites) */
ALTER TABLE public.verifications
    ADD COLUMN id        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
    ADD COLUMN "createdAt" TIMESTAMPTZ DEFAULT now(),
    ADD COLUMN "updatedAt" TIMESTAMPTZ DEFAULT now();


-- 1. Rename columns (each requires its own ALTER TABLE ... RENAME)
ALTER TABLE public.accounts RENAME COLUMN provider            TO "providerId";
ALTER TABLE public.accounts RENAME COLUMN "providerAccountId" TO "accountId";
ALTER TABLE public.accounts RENAME COLUMN refresh_token       TO "refreshToken";
ALTER TABLE public.accounts RENAME COLUMN access_token        TO "accessToken";
ALTER TABLE public.accounts RENAME COLUMN expires_at          TO "accessTokenExpiresAt";
ALTER TABLE public.accounts RENAME COLUMN id_token            TO "idToken";

-- 2 & 3. Drop obsolete columns and add the new timestamp columns in a single ALTER
ALTER TABLE public.accounts
    -- remove
    DROP COLUMN IF EXISTS type,
    DROP COLUMN IF EXISTS session_state,
    DROP COLUMN IF EXISTS token_type,
    -- add
    ADD COLUMN "createdAt" TIMESTAMPTZ DEFAULT now(),
    ADD COLUMN "updatedAt" TIMESTAMPTZ DEFAULT now();


-- 1. Rename existing columns
ALTER TABLE public.sessions
    RENAME COLUMN expires      TO "expiresAt";
ALTER TABLE public.sessions
    RENAME COLUMN "sessionToken" TO token;

-- 2. Add new columns (single ALTER to minimise rewrites)
ALTER TABLE public.sessions
    ADD COLUMN "createdAt" TIMESTAMPTZ DEFAULT now(),
    ADD COLUMN "updatedAt" TIMESTAMPTZ DEFAULT now(),
    ADD COLUMN "impersonatedBy" TEXT,
    ADD COLUMN "ipAddress" TEXT,
    ADD COLUMN "userAgent" TEXT;

SELECT * FROM accounts;