### PR TITLE
Feat/tag refactor

### DIFF
--- a/alembic/versions/39277f6278f4_add_view.py
+++ b/alembic/versions/39277f6278f4_add_view.py
@@ -147,7 +147,7 @@ def upgrade() -> None:
                 FROM slick_to_source sts
                 JOIN source s ON s.id = sts.source
                 JOIN slick sl ON sl.id = sts.slick
-                LEFT JOIN source_to_tag stt ON stt.source = sts.source
+                LEFT JOIN source_to_tag stt ON stt.source_ext_id = s.ext_id AND stt.source_type = s.type
                 LEFT JOIN hitl_slick hs ON hs.slick = sl.id
                 WHERE true 
                     AND sl.active 

--- a/alembic/versions/3c4693517ef6_add_tables.py
+++ b/alembic/versions/3c4693517ef6_add_tables.py
@@ -343,6 +343,7 @@ def upgrade() -> None:
         ),
         sa.Column("st_name", sa.Text, nullable=False),
         sa.Column("ext_id", sa.Text, nullable=False),
+        sa.UniqueConstraint("ext_id", "type", name="uq_source_extid_type"),
     )
 
     op.create_table(

--- a/alembic/versions/3c4693517ef6_add_tables.py
+++ b/alembic/versions/3c4693517ef6_add_tables.py
@@ -433,12 +433,18 @@ def upgrade() -> None:
 
     op.create_table(
         "source_to_tag",
-        sa.Column("source", sa.BigInteger, sa.ForeignKey("source.id"), nullable=False),
+        sa.Column("source_ext_id", sa.Text, nullable=False),
+        sa.Column("source_type", sa.BigInteger, nullable=False),
         sa.Column("tag", sa.BigInteger, sa.ForeignKey("tag.id"), nullable=False),
         sa.Column(
             "create_time", sa.DateTime, nullable=False, server_default=sa.func.now()
         ),
-        sa.PrimaryKeyConstraint("source", "tag"),
+        sa.ForeignKeyConstraint(
+            ["source_ext_id", "source_type"],
+            ["source.ext_id", "source.type"],
+            name="fk_source_to_tag_source_extid_type",
+        ),
+        sa.PrimaryKeyConstraint("source_ext_id", "source_type", "tag"),
     )
 
     op.create_table(

--- a/alembic/versions/7cd715196b8d_add_index.py
+++ b/alembic/versions/7cd715196b8d_add_index.py
@@ -80,7 +80,10 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """drop indices"""
-    op.drop_index("idx_source_to_tag_source", "source_to_tag")
+    # Drop indexes created on source_to_tag
+    op.drop_index("idx_source_to_tag_source_type", "source_to_tag")
+    op.drop_index("idx_source_to_tag_source_ext_id", "source_to_tag")
+    op.drop_index("idx_source_to_tag_source_pair", "source_to_tag")
     op.drop_index("idx_source_to_tag_tag", "source_to_tag")
 
     op.drop_index("idx_model_name", "model")

--- a/alembic/versions/7cd715196b8d_add_index.py
+++ b/alembic/versions/7cd715196b8d_add_index.py
@@ -66,7 +66,15 @@ def upgrade() -> None:
         postgresql_using="gist",
     )
 
-    op.create_index("idx_source_to_tag_source", "source_to_tag", ["source"])
+    op.create_index(
+        "idx_source_to_tag_source_pair",
+        "source_to_tag",
+        ["source_ext_id", "source_type"],
+    )
+    op.create_index(
+        "idx_source_to_tag_source_ext_id", "source_to_tag", ["source_ext_id"]
+    )
+    op.create_index("idx_source_to_tag_source_type", "source_to_tag", ["source_type"])
     op.create_index("idx_source_to_tag_tag", "source_to_tag", ["tag"])
 
 

--- a/cerulean_cloud/database_schema.py
+++ b/cerulean_cloud/database_schema.py
@@ -28,6 +28,7 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    ForeignKeyConstraint,
     Integer,
     String,
     Table,
@@ -229,14 +230,14 @@ class Trigger(Base):  # noqa
 class Users(Base):  # noqa
     __tablename__ = "users"
 
-    id = Column(BigInteger, primary_key=True)
+    id = Column(
+        BigInteger,
+        primary_key=True,
+        server_default=text("nextval('users_id_seq'::regclass)"),
+    )
     firstName = Column(Text)
     lastName = Column(Text)
-    name = Column(
-        Text,
-        Computed('(("firstName" || \' \'::text) || "lastName")', persisted=True),
-        nullable=False,
-    )
+    name = Column(Text)
     email = Column(Text, nullable=False, unique=True)
     emailVerified = Column(Boolean)
     image = Column(Text)
@@ -255,7 +256,11 @@ class Users(Base):  # noqa
 class Verifications(Base):  # noqa
     __tablename__ = "verifications"
 
-    id = Column(BigInteger, primary_key=True)
+    id = Column(
+        BigInteger,
+        primary_key=True,
+        server_default=text("nextval('verifications_id_seq'::regclass)"),
+    )
     identifier = Column(Text, nullable=False)
     value = Column(Text, nullable=False)
     expiresAt = Column(DateTime)
@@ -266,7 +271,11 @@ class Verifications(Base):  # noqa
 class Accounts(Base):  # noqa
     __tablename__ = "accounts"
 
-    id = Column(BigInteger, primary_key=True)
+    id = Column(
+        BigInteger,
+        primary_key=True,
+        server_default=text("nextval('accounts_id_seq'::regclass)"),
+    )
     userId = Column(ForeignKey("users.id"), nullable=False)
     providerId = Column(Text, nullable=False)
     accountId = Column(Text, nullable=False)
@@ -371,7 +380,11 @@ class OrchestratorRun(Base):  # noqa
 class Sessions(Base):  # noqa
     __tablename__ = "sessions"
 
-    id = Column(BigInteger, primary_key=True)
+    id = Column(
+        BigInteger,
+        primary_key=True,
+        server_default=text("nextval('sessions_id_seq'::regclass)"),
+    )
     userId = Column(ForeignKey("users.id"), nullable=False)
     expiresAt = Column(DateTime, nullable=False)
     token = Column(Text, nullable=False)
@@ -386,6 +399,7 @@ class Sessions(Base):  # noqa
 
 class Source(Base):  # noqa
     __tablename__ = "source"
+    __table_args__ = (UniqueConstraint("ext_id", "type"),)
 
     id = Column(
         BigInteger,
@@ -547,12 +561,18 @@ class Slick(Base):  # noqa
 
 class SourceToTag(Base):  # noqa
     __tablename__ = "source_to_tag"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["source_ext_id", "source_type"], ["source.ext_id", "source.type"]
+        ),
+    )
 
-    source = Column(ForeignKey("source.id"), primary_key=True, nullable=False)
+    source_ext_id = Column(Text, primary_key=True, nullable=False)
+    source_type = Column(BigInteger, primary_key=True, nullable=False)
     tag = Column(ForeignKey("tag.id"), primary_key=True, nullable=False)
     create_time = Column(DateTime, nullable=False, server_default=text("now()"))
 
-    source1 = relationship("Source")
+    source_ext = relationship("Source")
     tag1 = relationship("Tag")
 
 


### PR DESCRIPTION
```
BEGIN;

-- 1) Drop dependent view first
DROP VIEW IF EXISTS public.repeat_source;

-- 2) Ensure composite natural key exists on source
ALTER TABLE public.source
  ADD CONSTRAINT uq_source_ext_id_type UNIQUE (ext_id, type);

-- 3) Add new columns to carry composite reference
ALTER TABLE public.source_to_tag
  ADD COLUMN source_ext_id text,
  ADD COLUMN source_type bigint;

-- 4) Backfill from old FK column
UPDATE public.source_to_tag stt
SET source_ext_id = s.ext_id,
    source_type   = s.type
FROM public.source s
WHERE s.id = stt.source;

-- 5) Remove would-be duplicates before adding PK
DELETE FROM public.source_to_tag a
USING public.source_to_tag b
WHERE a.ctid < b.ctid
  AND a.tag = b.tag
  AND a.source_ext_id = b.source_ext_id
  AND a.source_type = b.source_type;

-- 6) Drop old PK/FK that referenced source.id
ALTER TABLE public.source_to_tag
  DROP CONSTRAINT IF EXISTS source_to_tag_pkey,
  DROP CONSTRAINT IF EXISTS source_to_tag_source_fkey;

-- 7) Not-null the new columns
ALTER TABLE public.source_to_tag
  ALTER COLUMN source_ext_id SET NOT NULL,
  ALTER COLUMN source_type   SET NOT NULL;

-- 8) New composite FK + PK
ALTER TABLE public.source_to_tag
  ADD CONSTRAINT fk_source_to_tag_source_extid_type
    FOREIGN KEY (source_ext_id, source_type)
    REFERENCES public.source (ext_id, type)
    ON UPDATE CASCADE ON DELETE RESTRICT,
  ADD CONSTRAINT source_to_tag_pkey
    PRIMARY KEY (source_ext_id, source_type, tag);

-- 9) Index maintenance
-- drop the old single-col index if it exists
DROP INDEX IF EXISTS public.idx_source_to_tag_source;

-- create the requested indexes
CREATE INDEX idx_source_to_tag_source_ext_id
  ON public.source_to_tag (source_ext_id);

CREATE INDEX idx_source_to_tag_source_type
  ON public.source_to_tag (source_type);

CREATE INDEX idx_source_to_tag_source_pair
  ON public.source_to_tag (source_ext_id, source_type);

-- keep existing idx_source_to_tag_tag as-is; create if you need it:
-- CREATE INDEX IF NOT EXISTS idx_source_to_tag_tag ON public.source_to_tag (tag);

-- 10) Drop the old referencing column
ALTER TABLE public.source_to_tag
  DROP COLUMN source;

-- 11) Recreate the view to join via (ext_id, type)
CREATE OR REPLACE VIEW public.repeat_source AS
WITH agg AS (
  SELECT 
    s.id AS source_id,
    COUNT(DISTINCT sl.orchestrator_run) AS occurrence_count,
    SUM(sl.area) / 1000000 AS total_area
  FROM slick_to_source sts
  JOIN source s ON s.id = sts.source
  JOIN slick sl ON sl.id = sts.slick
  LEFT JOIN source_to_tag stt
    ON stt.source_ext_id = s.ext_id
   AND stt.source_type   = s.type
  LEFT JOIN hitl_slick hs ON hs.slick = sl.id
  WHERE true 
    AND sl.active 
    AND sl.cls <> 1 
    AND (hs.cls IS NULL OR hs.cls <> 1) 
    AND sts.active 
    AND sts.hitl_verification IS NOT FALSE 
    AND (
      (s.type = 2 AND sts.rank = 1)
      OR 
      (s.type = 1 AND sts.collated_score > 0 AND (stt.tag IS NULL OR (stt.tag <> ALL (ARRAY[5, 6, 7]))))
    )
  GROUP BY s.id, s.ext_id, s.type
)
SELECT agg.source_id,
       agg.occurrence_count,
       agg.total_area,
       ROW_NUMBER() OVER (ORDER BY agg.occurrence_count DESC, agg.total_area DESC) AS global_rank
FROM agg
ORDER BY agg.occurrence_count DESC, agg.total_area DESC;

COMMIT;

```